### PR TITLE
Add kerberos support to the pipeline client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-core</artifactId>
-      <version>4.10.4</version>
+      <version>5.2.1</version>
       <type>jar</type>
       <scope>test</scope>
     </dependency>
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.solr</groupId>
       <artifactId>solr-solrj</artifactId>
-      <version>4.10.4</version>
+      <version>5.2.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/lucidworks/client/SecurityUtils.java
+++ b/src/main/java/com/lucidworks/client/SecurityUtils.java
@@ -1,0 +1,24 @@
+package com.lucidworks.client;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.solr.client.solrj.impl.HttpClientUtil;
+import org.apache.solr.client.solrj.impl.Krb5HttpClientConfigurer;
+
+public class SecurityUtils {
+  public static final String LWWW_JAAS_FILE = "lww.jaas.file";
+  public static final String LWWW_JAAS_APPNAME = "lww.jaas.appname";
+
+  private static Log log = LogFactory.getLog(SecurityUtils.class);
+
+  public static void setSecurityConfig() {
+    final String jassFile = System.getProperty(LWWW_JAAS_FILE);
+    if (jassFile != null) {
+      log.info("Using kerberized Solr.");
+      System.setProperty("java.security.auth.login.config", jassFile);
+      final String appname = System.getProperty(LWWW_JAAS_APPNAME, "Client");
+      System.setProperty("solr.kerberos.jaas.appname", appname);
+      HttpClientUtil.setConfigurer(new Krb5HttpClientConfigurer());
+    }
+  }
+}

--- a/src/main/java/com/lucidworks/client/SolrInputDocumentWriter.java
+++ b/src/main/java/com/lucidworks/client/SolrInputDocumentWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2013 NGDATA nv
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lucidworks.client;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.SolrInputDocument;
+
+/**
+ * Defines a generic writer of Solr data.
+ * <p>
+ * Implementations of this class may write directly to Solr, or to any other underlying
+ * store than can handle SolrInputDocuments.
+ */
+public interface SolrInputDocumentWriter {
+
+  /**
+   * Write a collection of documents to an underlying datastore.
+   *
+   * @param shard            shard id (ignored when using solr cloud)
+   * @param inputDocumentMap map of document ids to {@code SolrInputDocument}s
+   */
+  void add(int shard, Map<String, SolrInputDocument> inputDocumentMap) throws SolrServerException, IOException;
+
+  /**
+   * Delete a list of documents from an underlying datastore (optional operation).
+   *
+   * @param shard shard id (ignored when using solr cloud)
+   */
+  void deleteById(int shard, List<String> idsToDelete) throws SolrServerException, IOException;
+
+  /**
+   * Has the same behavior as {@link SolrClient#deleteByQuery(String)} (optional operation).
+   *
+   * @param deleteQuery delete query to be executed
+   */
+  void deleteByQuery(String deleteQuery) throws SolrServerException, IOException;
+
+  /**
+   * Close any open resources being used by this writer.
+   */
+  void close() throws SolrServerException, IOException;
+
+}


### PR DESCRIPTION
- Updated pom.xml to use solr 5.2.1 instead of 4.10.3
- Copied over the latest FusionPipelineClient/FusionDocumentWriter/SecurityUtils/SolrInputDocumentWriter from this commit : https://github.com/lucidworks/hbase-indexer/tree/dd948139dcedf227c37e4299b1ddfd88695b14ba/hbase-indexer-engine/src/main/java/com/ngdata/hbaseindexer/indexer
